### PR TITLE
feat: Add support for image_configuration block in serverless module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.78.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/modules/serverless/README.md
+++ b/modules/serverless/README.md
@@ -134,13 +134,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.62 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62 |
 
 ## Modules
 
@@ -165,6 +165,7 @@ No modules.
 | <a name="input_auto_stop_configuration"></a> [auto\_stop\_configuration](#input\_auto\_stop\_configuration) | The configuration for an application to automatically stop after a certain amount of time being idle | `any` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects nearly all resources) | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Determines whether the security group is created | `bool` | `true` | no |
+| <a name="input_image_configuration"></a> [image\_configuration](#input\_image\_configuration) | The image configuration applied to all worker types | `any` | `{}` | no |
 | <a name="input_initial_capacity"></a> [initial\_capacity](#input\_initial\_capacity) | The capacity to initialize when the application is created | `any` | `{}` | no |
 | <a name="input_maximum_capacity"></a> [maximum\_capacity](#input\_maximum\_capacity) | The maximum capacity to allocate when the application is created. This is cumulative across all workers at any given point in time, not just when an application is created. No new resources will be created once any one of the defined limits is hit | `any` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the application | `string` | `""` | no |

--- a/modules/serverless/main.tf
+++ b/modules/serverless/main.tf
@@ -83,6 +83,14 @@ resource "aws_emrserverless_application" "this" {
     }
   }
 
+  dynamic "image_configuration" {
+    for_each = length(var.image_configuration) > 0 ? [var.image_configuration] : []
+
+    content {
+      image_uri         = image_configuration.value.image_uri
+    }
+  }
+
   release_label = try(coalesce(var.release_label, element(data.aws_emr_release_labels.this[0].release_labels, 0)), "")
   type          = var.type
 

--- a/modules/serverless/main.tf
+++ b/modules/serverless/main.tf
@@ -87,7 +87,7 @@ resource "aws_emrserverless_application" "this" {
     for_each = length(var.image_configuration) > 0 ? [var.image_configuration] : []
 
     content {
-      image_uri         = image_configuration.value.image_uri
+      image_uri = image_configuration.value.image_uri
     }
   }
 

--- a/modules/serverless/variables.tf
+++ b/modules/serverless/variables.tf
@@ -32,6 +32,12 @@ variable "auto_stop_configuration" {
   default     = {}
 }
 
+variable "image_configuration" {
+  description = "The image configuration applied to all worker types"
+  type        = any
+  default     = {}
+}
+
 variable "initial_capacity" {
   description = "The capacity to initialize when the application is created"
   type        = any

--- a/modules/serverless/versions.tf
+++ b/modules/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 4.62"
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for image_configuration block in aws_emrserverless_application resource - it was added in aws provider 4.62.0

## Motivation and Context
Added possibility to use custom image in EMR serverless applications

## Breaking Changes
It requires aws provider in at least 4.62 version
