### PR TITLE
fix: Updating Kubernetes Role for EMR Virtual Cluster

### DIFF
--- a/modules/virtual-cluster/main.tf
+++ b/modules/virtual-cluster/main.tf
@@ -91,7 +91,7 @@ resource "kubernetes_role_v1" "this" {
   }
 
   rule {
-    api_groups = ["extensions"]
+    api_groups = ["extensions", "networking.k8s.io"]
     resources  = ["ingresses"]
     verbs      = ["get", "list", "watch", "describe", "create", "edit", "delete", "annotate", "patch", "label"]
   }
@@ -100,6 +100,12 @@ resource "kubernetes_role_v1" "this" {
     api_groups = ["rbac.authorization.k8s.io"]
     resources  = ["roles", "rolebindings"]
     verbs      = ["get", "list", "watch", "describe", "create", "edit", "delete", "deletecollection", "annotate", "patch", "label"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["persistentvolumeclaims"]
+    verbs      = ["get", "list", "watch", "describe", "create", "edit", "delete", "annotate", "patch", "label"]
   }
 }
 


### PR DESCRIPTION
## Description
Per Issue #11 , current `virtual-cluster` module defines a set of policy rules for the Kubernetes Role that is incomplete (current set of rules are defined in this [AWS doc](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-cluster-access.html#setting-up-cluster-access-manual)). This PR updates the role to include all missing rules.

## Motivation and Context
The PR is needed for proper configurations with EMR on EKS Virtual Cluster, i.e. creating [Managed Endpoints](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/connect-emr-studio.html) for interactive workloads with EMR Studip.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request

pre-commit output:
```
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
Terraform fmt............................................................Passed
Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
```