### PR TITLE
fix: Update EMR Role trust policy

### DIFF
--- a/modules/virtual-cluster/main.tf
+++ b/modules/virtual-cluster/main.tf
@@ -147,17 +147,6 @@ data "aws_iam_policy_document" "assume" {
   count = local.create_iam_role ? 1 : 0
 
   statement {
-    sid     = "EMR"
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["elasticmapreduce.${data.aws_partition.current.dns_suffix}"]
-    }
-  }
-
-  statement {
     sid     = "IRSA"
     effect  = "Allow"
     actions = ["sts:AssumeRoleWithWebIdentity"]


### PR DESCRIPTION
terraform version 1.5.0
aws providre version 5.4.0

According to terraform apply failure this statement is incorrect.

Error `MalformedPolicyDocument: Federated principals must be valid domain names or SAML metadata ARNs`

Docs for Job execution role does not contains any information about it either. 
https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/iam-execution-role.html

