### PR TITLE
docs: Update examples to show correct format for `ebs_config` input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.4
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ module "emr" {
       },
       {
         bid_price_as_percentage_of_on_demand_price = 100
-        ebs_config = {
-          size                 = 64
+        ebs_config = [{
+          size                 = 256
           type                 = "gp3"
           volumes_per_instance = 1
-        }
+        }]
         instance_type     = "c5.xlarge"
         weighted_capacity = 2
       },
@@ -110,11 +110,11 @@ module "emr" {
       },
       {
         bid_price_as_percentage_of_on_demand_price = 100
-        ebs_config = {
-          size                 = 64
+        ebs_config = [{
+          size                 = 256
           type                 = "gp3"
           volumes_per_instance = 1
-        }
+        }]
         instance_type     = "c5.xlarge"
         weighted_capacity = 2
       }
@@ -224,11 +224,11 @@ module "emr" {
     instance_type  = "c5.xlarge"
     bid_price      = "0.1"
 
-    ebs_config = {
-      size                 = 64
+    ebs_config = [{
+      size                 = 256
       type                 = "gp3"
       volumes_per_instance = 1
-    }
+    }]
     ebs_optimized = true
   }
 

--- a/examples/private-cluster/README.md
+++ b/examples/private-cluster/README.md
@@ -43,7 +43,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_emr_disabled"></a> [emr\_disabled](#module\_emr\_disabled) | ../.. | n/a |
 | <a name="module_emr_instance_fleet"></a> [emr\_instance\_fleet](#module\_emr\_instance\_fleet) | ../.. | n/a |
 | <a name="module_emr_instance_group"></a> [emr\_instance\_group](#module\_emr\_instance\_group) | ../.. | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.0 |
 | <a name="module_vpc_endpoints_sg"></a> [vpc\_endpoints\_sg](#module\_vpc\_endpoints\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |

--- a/examples/private-cluster/main.tf
+++ b/examples/private-cluster/main.tf
@@ -82,11 +82,11 @@ module "emr_instance_fleet" {
       },
       {
         bid_price_as_percentage_of_on_demand_price = 100
-        ebs_config = {
-          size                 = 64
+        ebs_config = [{
+          size                 = 256
           type                 = "gp3"
           volumes_per_instance = 1
-        }
+        }]
         instance_type     = "c5.xlarge"
         weighted_capacity = 2
       },
@@ -117,11 +117,11 @@ module "emr_instance_fleet" {
       },
       {
         bid_price_as_percentage_of_on_demand_price = 100
-        ebs_config = {
-          size                 = 64
+        ebs_config = [{
+          size                 = 256
           type                 = "gp3"
           volumes_per_instance = 1
-        }
+        }]
         instance_type     = "c5.xlarge"
         weighted_capacity = 2
       }
@@ -210,11 +210,11 @@ module "emr_instance_group" {
     instance_type  = "c5.xlarge"
     bid_price      = "0.1"
 
-    ebs_config = {
-      size                 = 64
+    ebs_config = [{
+      size                 = 256
       type                 = "gp3"
       volumes_per_instance = 1
-    }
+    }]
     ebs_optimized = true
   }
 
@@ -322,7 +322,7 @@ module "vpc_endpoints_sg" {
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   bucket_prefix = "${local.name}-"
 

--- a/examples/public-cluster/README.md
+++ b/examples/public-cluster/README.md
@@ -40,7 +40,7 @@ Note that this example may create resources which will incur monetary charges on
 |------|--------|---------|
 | <a name="module_emr_instance_fleet"></a> [emr\_instance\_fleet](#module\_emr\_instance\_fleet) | ../.. | n/a |
 | <a name="module_emr_instance_group"></a> [emr\_instance\_group](#module\_emr\_instance\_group) | ../.. | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources

--- a/examples/public-cluster/main.tf
+++ b/examples/public-cluster/main.tf
@@ -81,11 +81,11 @@ module "emr_instance_fleet" {
       },
       {
         bid_price_as_percentage_of_on_demand_price = 100
-        ebs_config = {
-          size                 = 64
+        ebs_config = [{
+          size                 = 256
           type                 = "gp3"
           volumes_per_instance = 1
-        }
+        }]
         instance_type     = "c5.xlarge"
         weighted_capacity = 2
       },
@@ -116,11 +116,11 @@ module "emr_instance_fleet" {
       },
       {
         bid_price_as_percentage_of_on_demand_price = 100
-        ebs_config = {
-          size                 = 64
+        ebs_config = [{
+          size                 = 256
           type                 = "gp3"
           volumes_per_instance = 1
-        }
+        }]
         instance_type     = "c5.xlarge"
         weighted_capacity = 2
       }
@@ -212,11 +212,11 @@ module "emr_instance_group" {
     instance_type  = "c5.xlarge"
     bid_price      = "0.1"
 
-    ebs_config = {
-      size                 = 64
+    ebs_config = [{
+      size                 = 256
       type                 = "gp3"
       volumes_per_instance = 1
-    }
+    }]
     ebs_optimized = true
   }
 
@@ -270,7 +270,7 @@ module "vpc" {
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   bucket_prefix = "${local.name}-"
 

--- a/examples/studio/README.md
+++ b/examples/studio/README.md
@@ -38,7 +38,7 @@ $ terraform apply
 | <a name="module_emr_studio_disabled"></a> [emr\_studio\_disabled](#module\_emr\_studio\_disabled) | ../../modules/studio | n/a |
 | <a name="module_emr_studio_iam"></a> [emr\_studio\_iam](#module\_emr\_studio\_iam) | ../../modules/studio | n/a |
 | <a name="module_emr_studio_sso"></a> [emr\_studio\_sso](#module\_emr\_studio\_sso) | ../../modules/studio | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources

--- a/examples/studio/main.tf
+++ b/examples/studio/main.tf
@@ -172,7 +172,7 @@ module "vpc" {
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   bucket_prefix = "${local.name}-"
 

--- a/examples/virtual-cluster/README.md
+++ b/examples/virtual-cluster/README.md
@@ -66,7 +66,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 | <a name="module_default"></a> [default](#module\_default) | ../../modules/virtual-cluster | n/a |
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../modules/virtual-cluster | n/a |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.13 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 | <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.0 |
 | <a name="module_vpc_endpoints_sg"></a> [vpc\_endpoints\_sg](#module\_vpc\_endpoints\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |

--- a/examples/virtual-cluster/main.tf
+++ b/examples/virtual-cluster/main.tf
@@ -295,7 +295,7 @@ module "vpc_endpoints_sg" {
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   bucket_prefix = "${local.name}-"
 


### PR DESCRIPTION
## Description
- Update examples to show correct format for `ebs_config` input

ℹ️  Note - the upstream provider is currently not functioning as intended for setting `ebs_config` on `instance_type_configs` or `core_instance_group`. I have tried adding a static `ebs_config` directly into the module source  and these changes were not detected by Terraform at this time

## Motivation and Context
- Resolves #19 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
