### PR TITLE
feat!: Add support for placement group config and unhealthy node replacement; raise AWS provider MSV to v5.44

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 
@@ -421,6 +421,7 @@ No modules.
 | <a name="input_master_security_group_description"></a> [master\_security\_group\_description](#input\_master\_security\_group\_description) | Description of the security group created | `string` | `"Managed master security group"` | no |
 | <a name="input_master_security_group_rules"></a> [master\_security\_group\_rules](#input\_master\_security\_group\_rules) | Security group rules to add to the security group created | `any` | <pre>{<br>  "default": {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "Allow all egress traffic",<br>    "from_port": 0,<br>    "ipv6_cidr_blocks": [<br>      "::/0"<br>    ],<br>    "protocol": "-1",<br>    "to_port": 0,<br>    "type": "egress"<br>  }<br>}</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the job flow | `string` | `""` | no |
+| <a name="input_placement_group_config"></a> [placement\_group\_config](#input\_placement\_group\_config) | The specified placement group configuration | `any` | `{}` | no |
 | <a name="input_release_label"></a> [release\_label](#input\_release\_label) | Release label for the Amazon EMR release | `string` | `null` | no |
 | <a name="input_release_label_filters"></a> [release\_label\_filters](#input\_release\_label\_filters) | Map of release label filters use to lookup a release label | `any` | <pre>{<br>  "default": {<br>    "prefix": "emr-6"<br>  }<br>}</pre> | no |
 | <a name="input_scale_down_behavior"></a> [scale\_down\_behavior](#input\_scale\_down\_behavior) | Way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an instance group is resized | `string` | `"TERMINATE_AT_TASK_COMPLETION"` | no |
@@ -443,6 +444,7 @@ No modules.
 | <a name="input_task_instance_fleet"></a> [task\_instance\_fleet](#input\_task\_instance\_fleet) | Configuration block to use an [Instance Fleet](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html) for the task node type. Cannot be specified if any `task_instance_group` configuration blocks are set | `any` | `{}` | no |
 | <a name="input_task_instance_group"></a> [task\_instance\_group](#input\_task\_instance\_group) | Configuration block to use an [Instance Group](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-groups) for the [task node type](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html#emr-plan-master) | `any` | `{}` | no |
 | <a name="input_termination_protection"></a> [termination\_protection](#input\_termination\_protection) | Switch on/off termination protection (default is `false`, except when using multiple master nodes). Before attempting to destroy the resource when termination protection is enabled, this configuration must be applied with its value set to `false` | `bool` | `null` | no |
+| <a name="input_unhealthy_node_replacement"></a> [unhealthy\_node\_replacement](#input\_unhealthy\_node\_replacement) | Whether whether Amazon EMR should gracefully replace core nodes that have degraded within the cluster. Default value is `false` | `bool` | `null` | no |
 | <a name="input_visible_to_all_users"></a> [visible\_to\_all\_users](#input\_visible\_to\_all\_users) | Whether the job flow is visible to all IAM users of the AWS account associated with the job flow. Default value is `true` | `bool` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the Amazon Virtual Private Cloud (Amazon VPC) where the security groups will be created | `string` | `""` | no |
 

--- a/examples/private-cluster/README.md
+++ b/examples/private-cluster/README.md
@@ -28,13 +28,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 

--- a/examples/private-cluster/main.tf
+++ b/examples/private-cluster/main.tf
@@ -146,10 +146,11 @@ module "emr_instance_fleet" {
   list_steps_states                 = ["PENDING", "RUNNING", "CANCEL_PENDING", "CANCELLED", "FAILED", "INTERRUPTED", "COMPLETED"]
   log_uri                           = "s3://${module.s3_bucket.s3_bucket_id}/"
 
-  scale_down_behavior    = "TERMINATE_AT_TASK_COMPLETION"
-  step_concurrency_level = 3
-  termination_protection = false
-  visible_to_all_users   = true
+  scale_down_behavior        = "TERMINATE_AT_TASK_COMPLETION"
+  step_concurrency_level     = 3
+  termination_protection     = false
+  unhealthy_node_replacement = true
+  visible_to_all_users       = true
 
   tags = local.tags
 }

--- a/examples/private-cluster/main.tf
+++ b/examples/private-cluster/main.tf
@@ -193,6 +193,14 @@ module "emr_instance_group" {
     }
   ])
 
+  #  Example placement group config for multiple primary node clusters
+  #  placement_group_config = [
+  #    {
+  #      instance_role      = "MASTER"
+  #      placement_strategy = "SPREAD"
+  #    }
+  #  ]
+
   master_instance_group = {
     name           = "master-group"
     instance_count = 1

--- a/examples/private-cluster/versions.tf
+++ b/examples/private-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
   }
 }

--- a/examples/public-cluster/README.md
+++ b/examples/public-cluster/README.md
@@ -26,13 +26,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 

--- a/examples/public-cluster/versions.tf
+++ b/examples/public-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
   }
 }

--- a/examples/serverless-cluster/README.md
+++ b/examples/serverless-cluster/README.md
@@ -26,13 +26,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 

--- a/examples/serverless-cluster/versions.tf
+++ b/examples/serverless-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
   }
 }

--- a/examples/studio/README.md
+++ b/examples/studio/README.md
@@ -22,13 +22,13 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 

--- a/examples/studio/versions.tf
+++ b/examples/studio/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
   }
 }

--- a/examples/virtual-cluster/README.md
+++ b/examples/virtual-cluster/README.md
@@ -45,7 +45,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.17 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |
@@ -54,7 +54,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.7 |
 

--- a/examples/virtual-cluster/versions.tf
+++ b/examples/virtual-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.tf
+++ b/main.tf
@@ -272,6 +272,15 @@ resource "aws_emr_cluster" "this" {
     }
   }
 
+  dynamic "placement_group_config" {
+    for_each = var.placement_group_config
+
+    content {
+      instance_role      = placement_group_config.value.instance_role
+      placement_strategy = try(placement_group_config.value.placement_strategy, null)
+    }
+  }
+
   name                   = var.name
   release_label          = try(coalesce(var.release_label, element(data.aws_emr_release_labels.this[0].release_labels, 0)), "")
   scale_down_behavior    = var.scale_down_behavior
@@ -299,9 +308,10 @@ resource "aws_emr_cluster" "this" {
     }
   }
 
-  step_concurrency_level = var.step_concurrency_level
-  termination_protection = var.termination_protection
-  visible_to_all_users   = var.visible_to_all_users
+  step_concurrency_level     = var.step_concurrency_level
+  termination_protection     = var.termination_protection
+  unhealthy_node_replacement = var.unhealthy_node_replacement
+  visible_to_all_users       = var.visible_to_all_users
 
   tags = merge(
     local.tags,

--- a/modules/serverless/README.md
+++ b/modules/serverless/README.md
@@ -134,13 +134,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.62 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 

--- a/modules/serverless/versions.tf
+++ b/modules/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.62"
+      version = ">= 5.44"
     }
   }
 }

--- a/modules/studio/README.md
+++ b/modules/studio/README.md
@@ -68,13 +68,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 
 ## Modules
 

--- a/modules/studio/versions.tf
+++ b/modules/studio/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
   }
 }

--- a/modules/virtual-cluster/README.md
+++ b/modules/virtual-cluster/README.md
@@ -82,14 +82,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.44 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.44 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
 
 ## Modules

--- a/modules/virtual-cluster/versions.tf
+++ b/modules/virtual-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,12 @@ variable "name" {
   default     = ""
 }
 
+variable "placement_group_config" {
+  description = "The specified placement group configuration"
+  type        = any
+  default     = {}
+}
+
 variable "release_label" {
   description = "Release label for the Amazon EMR release"
   type        = string
@@ -165,6 +171,12 @@ variable "step_concurrency_level" {
 
 variable "termination_protection" {
   description = "Switch on/off termination protection (default is `false`, except when using multiple master nodes). Before attempting to destroy the resource when termination protection is enabled, this configuration must be applied with its value set to `false`"
+  type        = bool
+  default     = null
+}
+
+variable "unhealthy_node_replacement" {
+  description = "Whether whether Amazon EMR should gracefully replace core nodes that have degraded within the cluster. Default value is `false`"
   type        = bool
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.42"
+      version = ">= 5.44"
     }
   }
 }


### PR DESCRIPTION
## Description
Adds support for cluster placement group config and unhealthy node replacement. 


## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/issues/36523
https://github.com/hashicorp/terraform-provider-aws/issues/30121

## Breaking Changes
Yes, bumps to aws provider v5. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
