### PR TITLE
Ops 13143/fix drift on demand

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -395,6 +395,12 @@ resource "aws_emr_instance_fleet" "this" {
   name                      = try(each.value.name, null)
   target_on_demand_capacity = try(each.value.target_on_demand_capacity, null)
   target_spot_capacity      = try(each.value.target_spot_capacity, null)
+
+  lifecycle {
+    ignore_changes = [
+      target_spot_capacity,
+    ]
+  }
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -398,7 +398,7 @@ resource "aws_emr_instance_fleet" "this" {
 
   lifecycle {
     ignore_changes = [
-      target_spot_capacity,
+      target_spot_capacity,target_on_demand_capacity
     ]
   }
 }


### PR DESCRIPTION
## Description
Modify the cluster to ignore on demand capacity changes too

## Motivation and Context
This prevents a redeployment of EMR clusters when the capacity target changes

## Breaking Changes
nonde


