### PR TITLE
fix: Align EMR EKS Job Execution role with AWS docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.0
+    rev: v1.99.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/modules/virtual-cluster/README.md
+++ b/modules/virtual-cluster/README.md
@@ -112,7 +112,6 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/virtual-cluster/main.tf
+++ b/modules/virtual-cluster/main.tf
@@ -147,17 +147,6 @@ data "aws_iam_policy_document" "assume" {
   count = local.create_iam_role ? 1 : 0
 
   statement {
-    sid     = "EMR"
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["elasticmapreduce.${data.aws_partition.current.dns_suffix}"]
-    }
-  }
-
-  statement {
     sid     = "IRSA"
     effect  = "Allow"
     actions = ["sts:AssumeRoleWithWebIdentity"]

--- a/modules/virtual-cluster/main.tf
+++ b/modules/virtual-cluster/main.tf
@@ -1,5 +1,4 @@
 data "aws_caller_identity" "current" {}
-data "aws_partition" "current" {}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id


### PR DESCRIPTION

## Description
Aligned EMR Job Execution role with: https://docs.aws.amazon.com/cli/latest/reference/emr-containers/update-role-trust-policy.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Aligned EMR Job Execution role with: https://docs.aws.amazon.com/cli/latest/reference/emr-containers/update-role-trust-policy.html

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
