### PR TITLE
feat: Support new EMR label in 6.2.0 of aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.2 |
 
 ## Modules
 
@@ -422,6 +422,7 @@ No modules.
 | <a name="input_master_security_group_description"></a> [master\_security\_group\_description](#input\_master\_security\_group\_description) | Description of the security group created | `string` | `"Managed master security group"` | no |
 | <a name="input_master_security_group_rules"></a> [master\_security\_group\_rules](#input\_master\_security\_group\_rules) | Security group rules to add to the security group created | `any` | <pre>{<br/>  "default": {<br/>    "cidr_blocks": [<br/>      "0.0.0.0/0"<br/>    ],<br/>    "description": "Allow all egress traffic",<br/>    "from_port": 0,<br/>    "ipv6_cidr_blocks": [<br/>      "::/0"<br/>    ],<br/>    "protocol": "-1",<br/>    "to_port": 0,<br/>    "type": "egress"<br/>  }<br/>}</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the job flow | `string` | `""` | no |
+| <a name="input_os_release_label"></a> [os\_release\_label](#input\_os\_release\_label) | OS release label for the Amazon EMR release | `string` | `"2023.7.20250512.0"` | no |
 | <a name="input_placement_group_config"></a> [placement\_group\_config](#input\_placement\_group\_config) | The specified placement group configuration | `any` | `{}` | no |
 | <a name="input_release_label"></a> [release\_label](#input\_release\_label) | Release label for the Amazon EMR release | `string` | `null` | no |
 | <a name="input_release_label_filters"></a> [release\_label\_filters](#input\_release\_label\_filters) | Map of release label filters use to lookup a release label | `any` | <pre>{<br/>  "default": {<br/>    "prefix": "emr-6"<br/>  }<br/>}</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -283,6 +283,7 @@ resource "aws_emr_cluster" "this" {
 
   name                   = var.name
   release_label          = try(coalesce(var.release_label, element(data.aws_emr_release_labels.this[0].release_labels, 0)), "")
+  os_release_label       = var.os_release_label
   scale_down_behavior    = var.scale_down_behavior
   security_configuration = var.create_security_configuration ? aws_emr_security_configuration.this[0].name : var.security_configuration_name
   service_role           = local.create_service_iam_role ? aws_iam_role.service[0].arn : var.service_iam_role_arn

--- a/main.tf
+++ b/main.tf
@@ -527,7 +527,7 @@ data "aws_iam_policy_document" "autoscaling" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:elasticmapreduce:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      values   = ["arn:aws:elasticmapreduce:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     }
   }
 }
@@ -591,7 +591,7 @@ data "aws_iam_policy_document" "service" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:elasticmapreduce:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      values   = ["arn:aws:elasticmapreduce:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,12 @@ variable "name" {
   default     = ""
 }
 
+variable "os_release_label" {
+  description = "OS release label for the Amazon EMR release"
+  type        = string
+  default     = "2023.7.20250512.0"
+}
+
 variable "placement_group_config" {
   description = "The specified placement group configuration"
   type        = any

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 6.2"
     }
   }
 }


### PR DESCRIPTION
* os_release_label

## Description
<!--- Describe your changes in detail -->

Added support for new resource options in `v6.2.0` of terraform of AWS provider (`os_release_label`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the when using v6.2.0 or higher of AWS provider the EMR cluster wants to replace `os_release_label` with null on every run of terraform causing issues to those who use the module.

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Needs a new major version
<!-- If so, please provide an explanation why it is necessary. -->
It is updating the minimum required Terraform AWS Provider version from 5.83 -> 6.2

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
