### PR TITLE
fix: EMR Serverless `runtime_configuration` should support multiple configurtions 

### DIFF
--- a/modules/serverless/main.tf
+++ b/modules/serverless/main.tf
@@ -164,7 +164,7 @@ resource "aws_emrserverless_application" "this" {
   }
 
   dynamic "runtime_configuration" {
-    for_each = var.runtime_configuration != null ? [var.runtime_configuration] : []
+    for_each = var.runtime_configuration != null ? var.runtime_configuration : []
 
     content {
       classification = runtime_configuration.value.classification


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> Removing a duplicate list [] to fix a bug

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> Fixing bug in v3.0.0
<!--- If it fixes an open issue, please link to the issue here. --> https://github.com/terraform-aws-modules/terraform-aws-emr/issues/46

## Breaking Changes
- Resolves #46

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
Terraform plan showed no error and displayed the changes expected and apply run with success

 # module.emr_apu.module.emr-serverless[0].module.emr-serverless-app-task.aws_emrserverless_application.this[0] will be updated in-place
  ~ resource "aws_emrserverless_application" "this" {
        id            = "00f******"
        name          = "core-2-emrapp-apu-eu-west-2"
        tags          = {
            "Application"           = "APU"
            "Environment"           = "2"
            "EnvironmentType"       = "Test"
            "ManagedByTerraform"    = "True"
            "terraform-aws-modules" = "emr"
        }
        # (6 unchanged attributes hidden)

      ~ monitoring_configuration {
          ~ cloudwatch_logging_configuration {
              ~ enabled                = false -> true
              + log_group_name         = "/aws/core-2-cwlog-eu-west-2/emr-serverless"
              + log_stream_name_prefix = "agreement-price-upload"
                # (1 unchanged attribute hidden)

              + log_types {
                  + name   = "SPARK_DRIVER"
                  + values = [
                      + "STDERR",
                      + "STDOUT",
                    ]
                }
              + log_types {
                  + name   = "SPARK_EXECUTOR"
                  + values = [
                      + "STDERR",
                      + "STDOUT",
                    ]
                }
            }

            # (1 unchanged block hidden)
        }

      ~ runtime_configuration {
          ~ properties     = {
              ~ "spark.executor.memory"                            = "18G" -> "20G"
                # (7 unchanged elements hidden)
            }
            # (1 unchanged attribute hidden)
        }

        # (7 unchanged blocks hidden)
    }


- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
