### PR TITLE
feat: Support `job_level_allocation_configuration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,13 +332,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 

--- a/examples/private-cluster/README.md
+++ b/examples/private-cluster/README.md
@@ -29,13 +29,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 

--- a/examples/private-cluster/versions.tf
+++ b/examples/private-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
   }
 }

--- a/examples/public-cluster/README.md
+++ b/examples/public-cluster/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 

--- a/examples/public-cluster/versions.tf
+++ b/examples/public-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
   }
 }

--- a/examples/serverless-cluster/README.md
+++ b/examples/serverless-cluster/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 

--- a/examples/serverless-cluster/versions.tf
+++ b/examples/serverless-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
   }
 }

--- a/examples/studio/README.md
+++ b/examples/studio/README.md
@@ -22,13 +22,13 @@ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 

--- a/examples/studio/versions.tf
+++ b/examples/studio/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
   }
 }

--- a/examples/virtual-cluster/README.md
+++ b/examples/virtual-cluster/README.md
@@ -41,7 +41,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.38 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |
@@ -50,7 +50,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules

--- a/examples/virtual-cluster/versions.tf
+++ b/examples/virtual-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/serverless/README.md
+++ b/modules/serverless/README.md
@@ -132,13 +132,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 
@@ -167,6 +167,7 @@ No modules.
 | <a name="input_image_configuration"></a> [image\_configuration](#input\_image\_configuration) | The image configuration applied to all worker types | <pre>object({<br/>    image_uri = string<br/>  })</pre> | `null` | no |
 | <a name="input_initial_capacity"></a> [initial\_capacity](#input\_initial\_capacity) | The capacity to initialize when the application is created | <pre>map(object({<br/>    initial_capacity_config = optional(object({<br/>      worker_configuration = optional(object({<br/>        cpu    = string<br/>        disk   = optional(string)<br/>        memory = string<br/>      }))<br/>      worker_count = optional(number, 1)<br/>    }))<br/>    initial_capacity_type = string<br/>  }))</pre> | `null` | no |
 | <a name="input_interactive_configuration"></a> [interactive\_configuration](#input\_interactive\_configuration) | Enables the interactive use cases to use when running an application | <pre>object({<br/>    livy_endpoint_enabled = optional(bool)<br/>    studio_enabled        = optional(bool)<br/>  })</pre> | `null` | no |
+| <a name="input_job_level_cost_allocation_configuration"></a> [job\_level\_cost\_allocation\_configuration](#input\_job\_level\_cost\_allocation\_configuration) | Configuration block for job-level cost allocation | <pre>object({<br/>    enabled = optional(bool)<br/>  })</pre> | `null` | no |
 | <a name="input_maximum_capacity"></a> [maximum\_capacity](#input\_maximum\_capacity) | The maximum capacity to allocate when the application is created. This is cumulative across all workers at any given point in time, not just when an application is created. No new resources will be created once any one of the defined limits is hit | <pre>object({<br/>    cpu    = string<br/>    disk   = optional(string)<br/>    memory = string<br/>  })</pre> | `null` | no |
 | <a name="input_monitoring_configuration"></a> [monitoring\_configuration](#input\_monitoring\_configuration) | The monitoring configuration for the application | <pre>object({<br/>    cloudwatch_logging_configuration = optional(object({<br/>      enabled                = optional(bool)<br/>      log_group_name         = optional(string)<br/>      log_stream_name_prefix = optional(string)<br/>      encryption_key_arn     = optional(string)<br/>      log_types = optional(list(object({<br/>        name   = string<br/>        values = list(string)<br/>      })))<br/>    }))<br/>    managed_persistence_monitoring_configuration = optional(object({<br/>      enabled            = optional(bool)<br/>      encryption_key_arn = optional(string)<br/>    }))<br/>    prometheus_monitoring_configuration = optional(object({<br/>      remote_write_url = optional(string)<br/>    }))<br/>    s3_monitoring_configuration = optional(object({<br/>      log_uri            = optional(string)<br/>      encryption_key_arn = optional(string)<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the application | `string` | `""` | no |

--- a/modules/serverless/main.tf
+++ b/modules/serverless/main.tf
@@ -84,6 +84,14 @@ resource "aws_emrserverless_application" "this" {
     }
   }
 
+  dynamic "job_level_cost_allocation_configuration" {
+    for_each = var.job_level_cost_allocation_configuration != null ? [var.job_level_cost_allocation_configuration] : []
+
+    content {
+      enabled = job_level_cost_allocation_configuration.value.enabled
+    }
+  }
+
   dynamic "maximum_capacity" {
     for_each = var.maximum_capacity != null ? [var.maximum_capacity] : []
 
@@ -187,7 +195,7 @@ resource "aws_emrserverless_application" "this" {
 ################################################################################
 
 locals {
-  create_security_group = var.create && var.create_security_group && try(var.network_configuration.subnet_ids, null) != null
+  create_security_group = var.create && var.create_security_group && try(length(var.network_configuration.subnet_ids), 0) > 0
   security_group_name   = try(coalesce(var.security_group_name, var.name), "")
 }
 

--- a/modules/serverless/variables.tf
+++ b/modules/serverless/variables.tf
@@ -76,6 +76,14 @@ variable "interactive_configuration" {
   default = null
 }
 
+variable "job_level_cost_allocation_configuration" {
+  description = "Configuration block for job-level cost allocation"
+  type = object({
+    enabled = optional(bool)
+  })
+  default = null
+}
+
 variable "maximum_capacity" {
   description = "The maximum capacity to allocate when the application is created. This is cumulative across all workers at any given point in time, not just when an application is created. No new resources will be created once any one of the defined limits is hit"
   type = object({

--- a/modules/serverless/versions.tf
+++ b/modules/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.35"
     }
   }
 


### PR DESCRIPTION
## Description
Support `aws_emrserverless_application.job_level_allocation_configuration`.

Also adjusted logic for `try(var.network_configuration.subnet_ids, null) != null` to `try(length(var.network_configuration.subnet_ids), 0) > 0` since it was producing an error in the example:
```
╷
│ Error: Invalid count argument
│ 
│   on ../../modules/serverless/main.tf line 203, in data "aws_subnet" "this":
│  203:   count = local.create_security_group ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined until
│ apply, so Terraform cannot predict how many instances will be created. To work
│ around this, use the -target argument to first apply only the resources that the
│ count depends on.
╵
```
In the example, the `subnet_ids` are not known until after the apply which produces this error. 

This allows the `count` to be determinable when `network_configuration` is not provided, while still properly tracking dependencies on module outputs.

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/46107

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
