### PR TITLE
fix: Update GitHub Actions and pre-commit hook versions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,7 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-comment: >

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.20.0
-  TFLINT_VERSION: v0.59.1
+  TERRAFORM_DOCS_VERSION: v0.24.0
+  TFLINT_VERSION: v0.64.0
 
 jobs:
   collectInputs:
@@ -18,7 +18,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get root directories
         id: dirs
@@ -33,7 +33,7 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Install rmz
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: SUPERCILEX/fuc
           asset-name: x86_64-unknown-linux-gnu-rmz
@@ -63,11 +63,11 @@ jobs:
           echo "=> Saved $(formatByteCount $SAVED)"
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
         with:
           directory: ${{ matrix.directory }}
 
@@ -95,7 +95,7 @@ jobs:
     needs: collectInputs
     steps:
       - name: Install rmz
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: SUPERCILEX/fuc
           asset-name: x86_64-unknown-linux-gnu-rmz
@@ -122,20 +122,24 @@ jobs:
           if [[ ${{ github.repository }} == terraform-aws-modules/terraform-aws-security-group ]]; then
             sudo rmz -f /usr/share/dotnet &
             sudo rmz -f /usr/local/.ghcup &
-            sudo apt-get -qq remove -y 'azure-.*'
-            sudo apt-get -qq remove -y 'cpp-.*'
-            sudo apt-get -qq remove -y 'dotnet-runtime-.*'
-            sudo apt-get -qq remove -y 'google-.*'
-            sudo apt-get -qq remove -y 'libclang-.*'
-            sudo apt-get -qq remove -y 'libllvm.*'
-            sudo apt-get -qq remove -y 'llvm-.*'
-            sudo apt-get -qq remove -y 'mysql-.*'
-            sudo apt-get -qq remove -y 'postgresql-.*'
-            sudo apt-get -qq remove -y 'php.*'
-            sudo apt-get -qq remove -y 'temurin-.*'
-            sudo apt-get -qq remove -y kubectl firefox mono-devel
+            # Disk cleanup is best-effort; tolerate transient apt mirror failures
+            set +e
+            sudo apt-get -qq update -y
+            sudo apt-get -qq remove -y --fix-missing 'azure-.*'
+            sudo apt-get -qq remove -y --fix-missing 'cpp-.*'
+            sudo apt-get -qq remove -y --fix-missing 'dotnet-runtime-.*'
+            sudo apt-get -qq remove -y --fix-missing 'google-.*'
+            sudo apt-get -qq remove -y --fix-missing 'libclang-.*'
+            sudo apt-get -qq remove -y --fix-missing 'libllvm.*'
+            sudo apt-get -qq remove -y --fix-missing 'llvm-.*'
+            sudo apt-get -qq remove -y --fix-missing 'mysql-.*'
+            sudo apt-get -qq remove -y --fix-missing 'postgresql-.*'
+            sudo apt-get -qq remove -y --fix-missing 'php.*'
+            sudo apt-get -qq remove -y --fix-missing 'temurin-.*'
+            sudo apt-get -qq remove -y --fix-missing kubectl firefox mono-devel
             sudo apt-get -qq autoremove -y
             sudo apt-get -qq clean
+            set -e
           fi
 
           wait
@@ -145,14 +149,14 @@ jobs:
           echo "=> Saved $(formatByteCount $SAVED)"
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v2.1.0
+        uses: clowdhaus/terraform-min-max@v3.0.1
 
       - name: Hide template dir
         # Special to this repo, we don't want to check this dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,26 +20,31 @@ jobs:
     if: github.repository_owner == 'terraform-aws-modules'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set correct Node.js version
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
       - name: Install dependencies
+        # conventional-changelog-conventionalcommits is held at 9.x on purpose.
+        # v10 replaced its handlebars templates with render functions, which need
+        # conventional-changelog-writer v9. semantic-release 25 still resolves
+        # writer v8, so v10 renders empty release notes without erroring.
+        # See https://github.com/semantic-release/release-notes-generator/issues/992
         run: |
           npm install \
-            @semantic-release/changelog@6.0.3 \
-            @semantic-release/git@10.0.1 \
-            conventional-changelog-conventionalcommits@9.1.0
+            @semantic-release/changelog@7.0.0 \
+            @semantic-release/git@11.0.1 \
+            conventional-changelog-conventionalcommits@9.3.1
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v5
+        uses: cycjimmy/semantic-release-action@v6.0.0
         with:
-          semantic_version: 25.0.0
+          semantic_version: 25.0.8
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 # Crash log files
 crash.log
 
-# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
 # password, private keys, and other secrets. These should not be part of version
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -330,14 +330,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
@@ -347,7 +347,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_emr_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_cluster) | resource |
 | [aws_emr_instance_fleet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_instance_fleet) | resource |
 | [aws_emr_instance_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_instance_group) | resource |
@@ -384,7 +384,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_info"></a> [additional\_info](#input\_additional\_info) | JSON string for selecting additional features such as adding proxy information. Note: Currently there is no API to retrieve the value of this argument after EMR cluster creation from provider, therefore Terraform cannot detect drift from the actual EMR cluster if its value is changed outside Terraform | `string` | `null` | no |
 | <a name="input_applications"></a> [applications](#input\_applications) | A case-insensitive list of applications for Amazon EMR to install and configure when launching the cluster | `list(string)` | `[]` | no |
 | <a name="input_auto_termination_policy"></a> [auto\_termination\_policy](#input\_auto\_termination\_policy) | An auto-termination policy for an Amazon EMR cluster. An auto-termination policy defines the amount of idle time in seconds after which a cluster automatically terminates | <pre>object({<br/>    idle_timeout = optional(number)<br/>  })</pre> | `null` | no |
@@ -463,7 +463,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_autoscaling_iam_role_arn"></a> [autoscaling\_iam\_role\_arn](#output\_autoscaling\_iam\_role\_arn) | Autoscaling IAM role ARN |
 | <a name="output_autoscaling_iam_role_name"></a> [autoscaling\_iam\_role\_name](#output\_autoscaling\_iam\_role\_name) | Autoscaling IAM role name |
 | <a name="output_autoscaling_iam_role_unique_id"></a> [autoscaling\_iam\_role\_unique\_id](#output\_autoscaling\_iam\_role\_unique\_id) | Stable and unique string identifying the autoscaling IAM role |

--- a/examples/private-cluster/README.md
+++ b/examples/private-cluster/README.md
@@ -27,20 +27,20 @@ Note that this example may create resources which will incur monetary charges on
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_emr_disabled"></a> [emr\_disabled](#module\_emr\_disabled) | ../.. | n/a |
 | <a name="module_emr_instance_fleet"></a> [emr\_instance\_fleet](#module\_emr\_instance\_fleet) | ../.. | n/a |
 | <a name="module_emr_instance_group"></a> [emr\_instance\_group](#module\_emr\_instance\_group) | ../.. | n/a |
@@ -51,7 +51,7 @@ Note that this example may create resources which will incur monetary charges on
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_instance_profile.custom_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.custom_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -69,7 +69,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_disabled_autoscaling_iam_role_arn"></a> [disabled\_autoscaling\_iam\_role\_arn](#output\_disabled\_autoscaling\_iam\_role\_arn) | Autoscaling IAM role ARN |
 | <a name="output_disabled_autoscaling_iam_role_name"></a> [disabled\_autoscaling\_iam\_role\_name](#output\_disabled\_autoscaling\_iam\_role\_name) | Autoscaling IAM role name |
 | <a name="output_disabled_autoscaling_iam_role_unique_id"></a> [disabled\_autoscaling\_iam\_role\_unique\_id](#output\_disabled\_autoscaling\_iam\_role\_unique\_id) | Stable and unique string identifying the autoscaling IAM role |

--- a/examples/public-cluster/README.md
+++ b/examples/public-cluster/README.md
@@ -25,20 +25,20 @@ Note that this example may create resources which will incur monetary charges on
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_emr_instance_fleet"></a> [emr\_instance\_fleet](#module\_emr\_instance\_fleet) | ../.. | n/a |
 | <a name="module_emr_instance_group"></a> [emr\_instance\_group](#module\_emr\_instance\_group) | ../.. | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 5.0 |
@@ -47,7 +47,7 @@ Note that this example may create resources which will incur monetary charges on
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
@@ -57,7 +57,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_fleet_autoscaling_iam_role_arn"></a> [fleet\_autoscaling\_iam\_role\_arn](#output\_fleet\_autoscaling\_iam\_role\_arn) | Autoscaling IAM role ARN |
 | <a name="output_fleet_autoscaling_iam_role_name"></a> [fleet\_autoscaling\_iam\_role\_name](#output\_fleet\_autoscaling\_iam\_role\_name) | Autoscaling IAM role name |
 | <a name="output_fleet_autoscaling_iam_role_unique_id"></a> [fleet\_autoscaling\_iam\_role\_unique\_id](#output\_fleet\_autoscaling\_iam\_role\_unique\_id) | Stable and unique string identifying the autoscaling IAM role |

--- a/examples/serverless-cluster/README.md
+++ b/examples/serverless-cluster/README.md
@@ -25,20 +25,20 @@ Note that this example may create resources which will incur monetary charges on
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_emr_serverless_disabled"></a> [emr\_serverless\_disabled](#module\_emr\_serverless\_disabled) | ../../modules/serverless | n/a |
 | <a name="module_emr_serverless_hive"></a> [emr\_serverless\_hive](#module\_emr\_serverless\_hive) | ../../modules/serverless | n/a |
 | <a name="module_emr_serverless_spark"></a> [emr\_serverless\_spark](#module\_emr\_serverless\_spark) | ../../modules/serverless | n/a |
@@ -47,7 +47,7 @@ Note that this example may create resources which will incur monetary charges on
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
@@ -57,7 +57,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_disabled_arn"></a> [disabled\_arn](#output\_disabled\_arn) | Amazon Resource Name (ARN) of the application |
 | <a name="output_disabled_id"></a> [disabled\_id](#output\_disabled\_id) | ID of the application |
 | <a name="output_disabled_security_group_arn"></a> [disabled\_security\_group\_arn](#output\_disabled\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |

--- a/examples/studio/README.md
+++ b/examples/studio/README.md
@@ -20,20 +20,20 @@ terraform apply
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_emr_studio_complete"></a> [emr\_studio\_complete](#module\_emr\_studio\_complete) | ../../modules/studio | n/a |
 | <a name="module_emr_studio_disabled"></a> [emr\_studio\_disabled](#module\_emr\_studio\_disabled) | ../../modules/studio | n/a |
 | <a name="module_emr_studio_iam"></a> [emr\_studio\_iam](#module\_emr\_studio\_iam) | ../../modules/studio | n/a |
@@ -45,7 +45,7 @@ terraform apply
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_identitystore_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group) | data source |
@@ -58,7 +58,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_complete_arn"></a> [complete\_arn](#output\_complete\_arn) | ARN of the studio |
 | <a name="output_complete_engine_security_group_arn"></a> [complete\_engine\_security\_group\_arn](#output\_complete\_engine\_security\_group\_arn) | Amazon Resource Name (ARN) of the engine security group |
 | <a name="output_complete_engine_security_group_id"></a> [complete\_engine\_security\_group\_id](#output\_complete\_engine\_security\_group\_id) | ID of the engine security group |

--- a/examples/virtual-cluster/README.md
+++ b/examples/virtual-cluster/README.md
@@ -39,7 +39,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.38 |
@@ -49,14 +49,14 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_complete"></a> [complete](#module\_complete) | ../../modules/virtual-cluster | n/a |
 | <a name="module_default"></a> [default](#module\_default) | ../../modules/virtual-cluster | n/a |
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../modules/virtual-cluster | n/a |
@@ -68,7 +68,7 @@ aws emr-containers list-virtual-clusters --region us-west-2 --states ARRESTED \
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [null_resource.s3_sync](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.start_job_run](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
@@ -80,7 +80,7 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_complete_cloudwatch_log_group_arn"></a> [complete\_cloudwatch\_log\_group\_arn](#output\_complete\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
 | <a name="output_complete_cloudwatch_log_group_name"></a> [complete\_cloudwatch\_log\_group\_name](#output\_complete\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
 | <a name="output_complete_job_execution_role_arn"></a> [complete\_job\_execution\_role\_arn](#output\_complete\_job\_execution\_role\_arn) | IAM role ARN of the job execution role |

--- a/modules/serverless/README.md
+++ b/modules/serverless/README.md
@@ -130,14 +130,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.35 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.35 |
 
 ## Modules
@@ -147,7 +147,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_emrserverless_application.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emrserverless_application) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
@@ -158,7 +158,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | The CPU architecture of an application. Valid values are `ARM64` or `X86_64`. Default value is `X86_64` | `string` | `null` | no |
 | <a name="input_auto_start_configuration"></a> [auto\_start\_configuration](#input\_auto\_start\_configuration) | The configuration for an application to automatically start on job submission | <pre>object({<br/>    enabled = optional(bool)<br/>  })</pre> | `null` | no |
 | <a name="input_auto_stop_configuration"></a> [auto\_stop\_configuration](#input\_auto\_stop\_configuration) | The configuration for an application to automatically stop after a certain amount of time being idle | <pre>object({<br/>    enabled              = optional(bool)<br/>    idle_timeout_minutes = optional(number)<br/>  })</pre> | `null` | no |
@@ -189,7 +189,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | Amazon Resource Name (ARN) of the application |
 | <a name="output_id"></a> [id](#output\_id) | ID of the application |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |

--- a/modules/studio/README.md
+++ b/modules/studio/README.md
@@ -66,14 +66,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 
 ## Modules
@@ -83,7 +83,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_emr_studio.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_studio) | resource |
 | [aws_emr_studio_session_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_studio_session_mapping) | resource |
 | [aws_iam_policy.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -112,7 +112,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_auth_mode"></a> [auth\_mode](#input\_auth\_mode) | Specifies whether the Studio authenticates users using IAM or Amazon Web Services SSO. Valid values are `SSO` or `IAM` | `string` | `"IAM"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (affects nearly all resources) | `bool` | `true` | no |
 | <a name="input_create_security_groups"></a> [create\_security\_groups](#input\_create\_security\_groups) | Determines whether security groups for the EMR Studio engine and workspace are created | `bool` | `true` | no |
@@ -167,7 +167,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the studio |
 | <a name="output_engine_security_group_arn"></a> [engine\_security\_group\_arn](#output\_engine\_security\_group\_arn) | Amazon Resource Name (ARN) of the engine security group |
 | <a name="output_engine_security_group_id"></a> [engine\_security\_group\_id](#output\_engine\_security\_group\_id) | ID of the engine security group |

--- a/modules/virtual-cluster/README.md
+++ b/modules/virtual-cluster/README.md
@@ -71,7 +71,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.38 |
@@ -79,7 +79,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.38 |
 
@@ -90,7 +90,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_emrcontainers_virtual_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emrcontainers_virtual_cluster) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -107,7 +107,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_annotations"></a> [annotations](#input\_annotations) | A map of annotations to add to all Kubernetes resources | `map(string)` | `{}` | no |
 | <a name="input_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#input\_cloudwatch\_log\_group\_arn) | ARN of the log group to use for the cluster logs | `string` | `"arn:aws:logs:*:*:*"` | no |
 | <a name="input_cloudwatch_log_group_class"></a> [cloudwatch\_log\_group\_class](#input\_cloudwatch\_log\_group\_class) | Specified the log class of the log group. Possible values are: `STANDARD` or `INFREQUENT_ACCESS` | `string` | `null` | no |
@@ -139,7 +139,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
 | <a name="output_job_execution_role_arn"></a> [job\_execution\_role\_arn](#output\_job\_execution\_role\_arn) | IAM role ARN of the job execution role |


### PR DESCRIPTION
## Description

- Update GitHub Actions to their latest versions:
  - `actions/checkout` v5 -> v7
  - `actions/setup-node` v6 -> v7
  - `actions/setup-python` v5 -> v7 (module specific workflows only)
  - `actions/stale` v10 -> v11
  - `dessant/lock-threads` v5 -> v6
  - `cycjimmy/semantic-release-action` v5 -> v6.0.0
  - `jaxxstorm/action-install-gh-release` v2.1.0 -> v3.0.0
  - `clowdhaus/terraform-min-max` v2.1.0 -> v3.0.1
  - `hashicorp/setup-terraform` v3 -> v4 (module specific workflows only)
- Update the tool versions used by the pre-commit workflow:
  - `terraform-docs` v0.20.0 -> v0.24.0
  - `tflint` v0.59.1 -> v0.64.0
- Update the release workflow dependencies:
  - `semantic-release` 25.0.0 -> 25.0.8
  - `@semantic-release/changelog` 6.0.3 -> 7.0.0
  - `@semantic-release/git` 10.0.1 -> 11.0.1
  - `conventional-changelog-conventionalcommits` 9.1.0 -> 9.3.1
- Update pre-commit hook versions via `pre-commit autoupdate` and re-format with `pre-commit run -a`
- Roll the hardened disk cleanup step out to all modules. The `apt-get` removals are now
  best effort, so a transient package mirror failure no longer fails the job.

### Note on `conventional-changelog-conventionalcommits`

This is intentionally held at the 9.x line rather than the latest 10.x. Version 10 replaced
its handlebars templates with render functions, which require `conventional-changelog-writer`
v9. `semantic-release` 25 still resolves `conventional-changelog-writer` v8, so the preset
loads without error but every release note and changelog entry renders empty. This is tracked
upstream in https://github.com/semantic-release/release-notes-generator/issues/992 and the
reasoning is recorded as a comment in the release workflow so it does not get "fixed" back
to 10.x by a future update.

## Motivation and Context

- Keeps our workflows on supported action versions
- Standardizes the common CI files across modules so these updates stay automatable

## Breaking Changes

- No

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
